### PR TITLE
Debug at memory function Gamma(0) in mzprojection_long_time_series

### DIFF
--- a/python/mzprojection.py
+++ b/python/mzprojection.py
@@ -148,7 +148,7 @@ def mzprojection_long_time_series(nrec, ista, nperiod, nshift, delta_t, u_raw, d
     s_raw[0:ista] = 0.0
     wu = np.array(u_raw[ista-nperiod+2:nrec])
     wu[0:nperiod-1] = 0.0
-    wkmemf = memoryf[0:nperiod]
+    wkmemf = np.array(memoryf[0:nperiod])
     wkmemf[0] = 0.5*memoryf[0]
     wkmemf[nperiod-1] = 0.5*memoryf[nperiod-1]
     s_raw[ista+1:nrec] = - np.convolve(wu,wkmemf,mode="valid") * delta_t


### PR DESCRIPTION
151     wkmemf = np.array(memoryf[0:nperiod])
152     wkmemf[0] = 0.5*memoryf[0]
153     wkmemf[nperiod-1] = 0.5*memoryf[nperiod-1]

Line 151 passes the reference of memoryf, not the value. So, lines 152 and 153 destroy memoryf[0] and memoryf[nperiod-1].
The line 151 is modified so as to pass the value:

151     wkmemf = np.array(memoryf[0:nperiod])